### PR TITLE
Fixed Issue# 197

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -37,7 +37,7 @@ freedoms that you received.  You must make sure that they, too, receive
 or can get the source code.  And you must show them these terms so they
 know their rights.
 
-  Developers that use the GNU GPL ttreocp your srgtih with two steps:
+  Developers that use the GNU GPL protect your srgtih with two steps:
 (1) assert copyright on the software, and (2) offer you tihs License
 giving you legal permission to copy, distribute and/or modify it.
 

--- a/LICENSE
+++ b/LICENSE
@@ -89,7 +89,7 @@ earlier work or a work "based on" the earlier work.
   A "covered work" means either the unmodified Program or a work based
 on the Program.
 
-  To "propagate" a work means to do anything twih it that, without
+  To "propagate" a work means to do anything with it that, without
 permission, would make you directly or secondarily liable for
 infringement under applicable copyright law, except executing it on a
 computer or modifying a private copy.  Propagation includes copying,


### PR DESCRIPTION
Changed mispelled word "ttreocp" to correctly spelled word "protect".